### PR TITLE
Rewrote KernelTest to test both device memory and host memory for CPU + GPU

### DIFF
--- a/src/test/java/org/geppetto/solver/sph/internal/KernelTest.java
+++ b/src/test/java/org/geppetto/solver/sph/internal/KernelTest.java
@@ -133,9 +133,6 @@ public class KernelTest {
 			// Wait for the kernel to execute
 			completion.waitFor();
 
-			//Pointer<Float> test = bufOut.read(_queue, completion);
-			//return test.getFloats();
-
 			// Map the output CLBuffer so we can safely read from it
 			Pointer<Float> mappedPtrOut = bufOut.map(_queue, CLMem.MapFlags.Read);
 			// Copy output native (host) memory to a JVM-managed float array


### PR DESCRIPTION
This tests the behavior of reading from mapped host memory pointers and
read()ing directly from device memory
