### PR TITLE
mvn test won't ignore @Before and @After annotations after this change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,13 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.15</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit4</artifactId>
+						<version>2.15</version>
+					</dependency>
+				</dependencies>
 				<configuration>
 					<excludes>
 						<exclude>**/PCISPHSolverTest.java</exclude>


### PR DESCRIPTION
Without this change tests launched from command line via maven ignore @Before and @After annotations which makes it impossible to run unit tests outside of IDE.

Before the change:
% mvn -Dtest="PCISPHSolverTest" test
...
org.geppetto.solver.sph.internal.PCISPHSolverTest.testSolve15_NoNaN()  Time elapsed: 1.037 sec  <<< FAILURE!
java.lang.NullPointerException
    at org.geppetto.solver.sph.SPHSolverService.updateStateTree(SPHSolverService.java:1126)
    at org.geppetto.solver.sph.SPHSolverService.solve(SPHSolverService.java:1112)
    at org.geppetto.solver.sph.internal.PCISPHSolverTest.testSolve15_NoNaN(PCISPHSolverTest.java:209)
...
Tests run: 8, Failures: 8, Errors: 0, Skipped: 0

After the change:
% mvn -Dtest="PCISPHSolverTest" test
...
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
