### PR TITLE
Removed some unnecessary map/unmap calls in SPHSolverService.

### DIFF
--- a/src/main/java/org/geppetto/solver/sph/SPHSolverService.java
+++ b/src/main/java/org/geppetto/solver/sph/SPHSolverService.java
@@ -1017,24 +1017,14 @@ public class SPHSolverService extends AService implements ISolver {
 	 * @param simulationTree
 	 */
 	private void updateSimulationTree(AspectSubTreeNode simulationTree) {
-		// map watchable buffers that are not already mapped
-		// NOTE: position is mapped for scene generation - improving performance
-		// by not mapping it again
-		_velocityPtr = _velocity.map(_queue, CLMem.MapFlags.Read);
-
 		if (simulationTree.getChildren().isEmpty()) {
 			simulationTree.setId(AspectTreeType.SIMULATION_TREE.toString());
-			//@tarelli Commented out next line
-			//populateSimulationTree(simulationTree);
 		} else {
 			// watch tree not empty populate new values
 			UpdateSPHSimulationTreeVisitor visitor = new UpdateSPHSimulationTreeVisitor(
 					_positionPtr);
 			simulationTree.apply(visitor);
 		}
-
-		// unmap watchable buffers
-		_velocity.unmap(_queue, _positionPtr);
 	}
 
 	private boolean containsNode(ACompositeNode node, String name) {


### PR DESCRIPTION
Removed an unnecessary map/unmap call in SPHSolverService that caused exceptions on AWS g2 instances. The code was mapping the velocity buffer and then unmapping it without every actually reading it.

I also removed some comments that seemed unnecessary as well. Please let me know if you'd like me to put them back or add other comments.

The unmap call was failing on the g2 instance (NVIDIA GRID GPU). It's not clear if this is a bug in the OpenCL implementation or if it's a timing issue. Perhaps the unmap call happens before the map operation has completed.

GPU/Driver Details:
* device - 0: GRID K520 (NVIDIA CUDA)
* Version OpenCL C 1.2 
* Version 349.16
* using GRID K520 (NVIDIA CUDA)
* max workgroup size: 1024
* max workitems size: 1024

The exception:
```
com.nativelibs4java.opencl.CLException$InvalidValue: InvalidValue (make sure to log all errors with environment variable CL_LOG_ERRORS=stdout)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at java.lang.Class.newInstance(Class.java:379)
	at com.nativelibs4java.opencl.CLException.error(CLException.java:260)
	at com.nativelibs4java.opencl.CLBuffer.unmap(CLBuffer.java:281)
	at org.geppetto.solver.sph.SPHSolverService.updateSimulationTree(SPHSolverService.java:1037)
	at org.geppetto.solver.sph.SPHSolverService.updateStateTree(SPHSolverService.java:999)
	at org.geppetto.solver.sph.SPHSolverService.solve(SPHSolverService.java:975)
	at org.geppetto.solver.sph.internal.PhysicsLawsTest.testGravitation_SingleParticle(PhysicsLawsTest.java:60)
```